### PR TITLE
make read_message handle json load properly

### DIFF
--- a/wayfire/ipc.py
+++ b/wayfire/ipc.py
@@ -46,7 +46,7 @@ class WayfireSocket:
         self.client.close()
 
     def decode_utf(self, byte_data: bytes):
-        encodings = ['utf-8', 'utf-16', 'utf-32', 'utf-7', 'utf-1']
+        encodings = ['utf-8', 'utf-16', 'utf-32']
         for encoding in encodings:
             try:
                 return byte_data.decode(encoding)


### PR DESCRIPTION
The issue with read_message was that if an invalid response was passed to json loads, the function would fail to read the message, causing read_next_event to break too. I updated read_message to properly handle these cases by returning None when it can't read the message, ensuring that read_next_event can continue functioning without breaking.


since IPC returns raw Unicode, here's an example of what may happen with: 


```
In [2]: import json
In [3]: json_string = r'"\U001015db\U0008ab7d\U00103216\U00086e15\U000e2f88\U001084d6\U000xyz00"'

In [4]: json.loads(json_string)
---------------------------------------------------------------------------
JSONDecodeError                           Traceback (most recent call last)
Cell In[4], line 1
----> 1 json.loads(json_string)

File /usr/lib/python3.12/json/__init__.py:346, in loads(s, cls, object_hook, parse_float, parse_int, parse_constant, object_pairs_hook, **kw)
    341     s = s.decode(detect_encoding(s), 'surrogatepass')
    343 if (cls is None and object_hook is None and
    344         parse_int is None and parse_float is None and
    345         parse_constant is None and object_pairs_hook is None and not kw):
--> 346     return _default_decoder.decode(s)
    347 if cls is None:
    348     cls = JSONDecoder

File /usr/lib/python3.12/json/decoder.py:337, in JSONDecoder.decode(self, s, _w)
    332 def decode(self, s, _w=WHITESPACE.match):
    333     """Return the Python representation of ``s`` (a ``str`` instance
    334     containing a JSON document).
    335 
    336     """
--> 337     obj, end = self.raw_decode(s, idx=_w(s, 0).end())
    338     end = _w(s, end).end()
    339     if end != len(s):

File /usr/lib/python3.12/json/decoder.py:353, in JSONDecoder.raw_decode(self, s, idx)
    344 """Decode a JSON document from ``s`` (a ``str`` beginning with
    345 a JSON document) and return a 2-tuple of the Python
    346 representation and the index in ``s`` where the document ended.
   (...)
    350 
    351 """
    352 try:
--> 353     obj, end = self.scan_once(s, idx)
    354 except StopIteration as err:
    355     raise JSONDecodeError("Expecting value", s, err.value) from None

JSONDecodeError: Invalid \escape: line 1 column 2 (char 1)
```