### PR TITLE
Add meson.build file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,11 @@
+project(
+	'pywayfire',
+	version: '3.2',
+	license: 'MIT',
+	meson_version: '>=0.55',
+)
+
+dependency('wayfire', required: false)
+pip = find_program('pip')
+
+message(run_command(pip, 'install', '.', '--break-system-packages', check: true).stdout().strip())


### PR DESCRIPTION
This simply calls 'pip install . --break-system-packages' as a convenience wrapper so it can be included as a subproject in others that use the meson build system. To install, simply run 'meson setup build'. Build and install commands will not have any targets, but they will succeed nonetheless.